### PR TITLE
use process.env.[ENV_NAME] in generateTypes to automate getting server url

### DIFF
--- a/generateTypes.ts
+++ b/generateTypes.ts
@@ -1,10 +1,13 @@
+const dotenv = require("dotenv");
+dotenv.config();
+
 const { generateApi } = require("swagger-typescript-api");
 const path = require("path");
 
 generateApi({
   name: "novel-server.types.ts",
   output: path.resolve(process.cwd(), "./src/types"),
-  url: "http://localhost:4000/swagger-schema.json",
+  url: `${process.env.REACT_APP_API_URL}/swagger-schema.json`,
   generateClient: false,
   generateRouteTypes: false,
 }).catch((e) => console.error(e));


### PR DESCRIPTION
when creating types